### PR TITLE
プルダウンメニューの修正

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,10 +6,10 @@ name = "pypi"
 [packages]
 requests = "*"
 flask = "*"
-numpy = "*"
 plotly = "*"
 pandas = "*"
 gunicorn = "*"
+numpy = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,10 +25,11 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "click": {
             "hashes": [
@@ -212,11 +213,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
-                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
             "index": "pypi",
-            "version": "==2.25.0"
+            "version": "==2.25.1"
         },
         "retrying": {
             "hashes": [

--- a/flavor_chart.py
+++ b/flavor_chart.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
           <div class="form-group">
             <label for="area">地域：</label>
             <select name="area" onchange="submit(this.form)" class="form-control">
-              <option value="">選択してください</option>
+              <option disabled selected value>選択してください</option>
               {% for area in areas %}
                 {% if area["id"] == area_id %}
                   <option value="{{ area["id"] }}" selected>{{ area["name"] }}</option>
@@ -40,7 +40,9 @@
             <label for="brewery">蔵元：</label>
             <select name="brewery" onchange="submit(this.form)" class="form-control">
               {% for brewery in breweries %}
-                {% if brewery["id"] == brewery_id %}
+                {% if brewery["id"] == "" %}
+                  <option disabled selected value>{{ brewery["name"] }}</option>
+                {% elif brewery["id"] == brewery_id %}
                   <option value="{{ brewery["id"] }}" selected>{{ brewery["name"] }}</option>
                 {% else %}
                   <option value="{{ brewery["id"] }}">{{ brewery["name"] }}</option>
@@ -59,7 +61,9 @@
             <label for="brand">銘柄：</label>
             <select name="brand" onchange="submit(this.form)" class="form-control">
               {% for brand in brands %}
-                {% if brand["id"] == brand_id %}
+                {% if brand["id"] == "" %}
+                  <option disabled selected value>{{ brand["name"] }}</option>
+                {% elif brand["id"] == brand_id %}
                   <option value="{{ brand["id"] }}" selected>{{ brand["name"] }}</option>
                 {% else %}
                   <option value="{{ brand["id"] }}">{{ brand["name"] }}</option>
@@ -97,7 +101,9 @@
           <div class="form-group">
               <select name="selected_brand" onchange="submit(this.form)" class="form-control">
                 {% for search_brand in search_brands %}
-                  {% if search_brand["id"] == selected_brand_id %}
+                  {% if search_brand["id"] == "" %}
+                    <option disabled selected value>{{ search_brand["name"] }}</option>
+                  {% elif search_brand["id"] == selected_brand_id %}
                     <option value="{{ search_brand["id"] }}" selected>{{ search_brand["name"] }}</option>
                   {% else %}
                     <option value="{{ search_brand["id"] }}">{{ search_brand["name"] }}</option>


### PR DESCRIPTION
# Why
プルダウンメニュー先頭の「選択してください」等の文言が地域名/蔵元名/銘柄名として選択できるようになってしまっていたため。

# What
該当するoptionタグに"disabled selected value"属性を付与し、選択できないように修正。